### PR TITLE
Refactor common props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mendix/pluggable-widgets-typing-generator",
-    "version": "8.3.1",
+    "version": "8.4.0",
     "description": "Mendix Pluggable Widgets typings generator",
     "license": "Apache-2.0",
     "copyright": "Mendix 2019",

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -408,7 +408,7 @@ ${modelerVisibilityMap}
         ? `class: string;
     style?: CSSProperties;
     tabIndex: number;`
-        : "style: Style[];";
+        : "style: Partial<Style>[];";
     return `/**
  * This file was generated from ${widgetName}.xml
  * WARNING: All changes made to this file will be overwritten

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -408,7 +408,7 @@ ${modelerVisibilityMap}
         ? `class: string;
     style?: CSSProperties;
     tabIndex: number;`
-        : "style: Partial<Style>[];";
+        : "style: Array<Partial<Style>>;";
     return `/**
  * This file was generated from ${widgetName}.xml
  * WARNING: All changes made to this file will be overwritten

--- a/tests/outputs.ts
+++ b/tests/outputs.ts
@@ -7,7 +7,7 @@ import { ActionValue, DynamicValue, EditableValue, NativeImage } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Partial<Style>[];
+    style: Array<Partial<Style>>;
 }
 
 export type BootstrapStyleEnum = "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";

--- a/tests/outputs.ts
+++ b/tests/outputs.ts
@@ -7,7 +7,7 @@ import { ActionValue, DynamicValue, EditableValue, NativeImage } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Style[];
+    style: Partial<Style>[];
 }
 
 export type BootstrapStyleEnum = "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";

--- a/tests/outputs/containment.ts
+++ b/tests/outputs/containment.ts
@@ -46,7 +46,7 @@ import { ReactNode } from "react";
 
 interface CommonProps<Style> {
     name: string;
-    style: Partial<Style>[];
+    style: Array<Partial<Style>>;
 }
 
 export interface MyWidgetProps<Style> extends CommonProps<Style> {

--- a/tests/outputs/containment.ts
+++ b/tests/outputs/containment.ts
@@ -46,7 +46,7 @@ import { ReactNode } from "react";
 
 interface CommonProps<Style> {
     name: string;
-    style: Style[];
+    style: Partial<Style>[];
 }
 
 export interface MyWidgetProps<Style> extends CommonProps<Style> {

--- a/tests/outputs/icon.ts
+++ b/tests/outputs/icon.ts
@@ -54,7 +54,7 @@ import { DynamicValue, NativeIcon } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Partial<Style>[];
+    style: Array<Partial<Style>>;
 }
 
 export interface IconsType {

--- a/tests/outputs/icon.ts
+++ b/tests/outputs/icon.ts
@@ -54,7 +54,7 @@ import { DynamicValue, NativeIcon } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Style[];
+    style: Partial<Style>[];
 }
 
 export interface IconsType {

--- a/tests/outputs/list-action.ts
+++ b/tests/outputs/list-action.ts
@@ -53,7 +53,7 @@ import { ActionValue, EditableValue } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Style[];
+    style: Partial<Style>[];
 }
 
 export interface ActionsType {

--- a/tests/outputs/list-action.ts
+++ b/tests/outputs/list-action.ts
@@ -53,7 +53,7 @@ import { ActionValue, EditableValue } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Partial<Style>[];
+    style: Array<Partial<Style>>;
 }
 
 export interface ActionsType {

--- a/tests/outputs/list-image.ts
+++ b/tests/outputs/list-image.ts
@@ -50,7 +50,7 @@ import { DynamicValue, NativeImage } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Partial<Style>[];
+    style: Array<Partial<Style>>;
 }
 
 export interface ActionsType {

--- a/tests/outputs/list-image.ts
+++ b/tests/outputs/list-image.ts
@@ -50,7 +50,7 @@ import { DynamicValue, NativeImage } from "mendix";
 
 interface CommonProps<Style> {
     name: string;
-    style: Style[];
+    style: Partial<Style>[];
 }
 
 export interface ActionsType {


### PR DESCRIPTION
Change the style prop typing to an array of elements with the partial style type, because that's how the MX client actually provides it